### PR TITLE
don't mix async and callback in lambda function signature

### DIFF
--- a/docs/10-integrate-with-s3.md
+++ b/docs/10-integrate-with-s3.md
@@ -75,7 +75,7 @@ will also be sent back to the lambda. These are ignored.
 ➜  echo "const AWS = require('aws-sdk');
          const s3 = new AWS.S3();
          
-         exports.handler = async (event, context, callback) => {
+         exports.handler = (event, context, callback) => {
            const uploadedObject = event.Records[0].s3.object;
            const objectKey = uploadedObject.key;
            if (\!objectKey.includes('metadata.txt')) {

--- a/docs/11-integrate-with-kinesis.md
+++ b/docs/11-integrate-with-kinesis.md
@@ -113,7 +113,7 @@ Stream records read from Kinesis, by Lambda, will have the format mentioned belo
 ```
 ➜ mkdir kinesis-event-logger-lambda
 ➜ cd kinesis-event-logger-lambda
-➜ echo "exports.handler =  async (event, context, callback) => {
+➜ echo "exports.handler =  async (event, context) => {
   event.Records.forEach(record => console.log(Buffer.from(record.kinesis.data, 'base64').toString('utf8')));
 };" > kinesisEventLogger.js
 ```

--- a/docs/12-integrate-with-dynamodb.md
+++ b/docs/12-integrate-with-dynamodb.md
@@ -131,7 +131,7 @@ StreamViewType, the `Records.dynamodb.Keys` will only have the `Keys`. The dynam
 ```shell script
 ➜ mkdir dynamodb-event-logger-lambda
 ➜ cd dynamodb-event-logger-lambda
-➜ echo "exports.handler =  async (event, context, callback) => {
+➜ echo "exports.handler =  async (event, context) => {
   event.Records.forEach(record => console.log(record.dynamodb.Keys));
 };" > dynamoDBEventLogger.js
 ```

--- a/samples/09/s3-event-listener-lambda/s3ObjectListenerLambda.js
+++ b/samples/09/s3-event-listener-lambda/s3ObjectListenerLambda.js
@@ -1,7 +1,7 @@
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3();
 
-exports.handler = async (event, context, callback) => {
+exports.handler = (event, context, callback) => {
   const uploadedObject = event.Records[0].s3.object;
   const objectKey = uploadedObject.key;
   if (!objectKey.includes('metadata.json')) {

--- a/samples/10/kinesis-event-logger-lambda/kinesisEventLogger.js
+++ b/samples/10/kinesis-event-logger-lambda/kinesisEventLogger.js
@@ -1,3 +1,3 @@
-exports.handler =  async (event, context, callback) => {
+exports.handler =  async (event, context) => {
   event.Records.forEach(record => console.log(Buffer.from(record.kinesis.data, 'base64').toString('utf8')));
 };

--- a/samples/11/dynamodb-event-logger-lambda/dynamoDBEventLogger.js
+++ b/samples/11/dynamodb-event-logger-lambda/dynamoDBEventLogger.js
@@ -1,3 +1,3 @@
-exports.handler =  async (event, context, callback) => {
+exports.handler =  async (event, context) => {
   event.Records.forEach(record => console.log(record.dynamodb.Keys));
 };


### PR DESCRIPTION
This repo is an awesome resource to get started with AWS Lambda!

This `PR` fixes some function signatures.

async functions should not call a callback, if a function returns a promise the runtime waits for the promise to be resolved or rejected.